### PR TITLE
Fixed the include directory's wrong upper case character.

### DIFF
--- a/LTBL2/source/ltbl/quadtree/DynamicQuadtree.cpp
+++ b/LTBL2/source/ltbl/quadtree/DynamicQuadtree.cpp
@@ -1,4 +1,4 @@
-#include <ltbl/Quadtree/DynamicQuadtree.h>
+#include <ltbl/quadtree/DynamicQuadtree.h>
 
 #include <assert.h>
 

--- a/LTBL2/source/ltbl/quadtree/DynamicQuadtree.h
+++ b/LTBL2/source/ltbl/quadtree/DynamicQuadtree.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <ltbl/Quadtree/Quadtree.h>
+#include <ltbl/quadtree/Quadtree.h>
 
 namespace ltbl {
 	class DynamicQuadtree : public Quadtree {

--- a/LTBL2/source/ltbl/quadtree/Quadtree.cpp
+++ b/LTBL2/source/ltbl/quadtree/Quadtree.cpp
@@ -1,4 +1,4 @@
-#include <ltbl/Quadtree/Quadtree.h>
+#include <ltbl/quadtree/Quadtree.h>
 
 #include <algorithm>
 

--- a/LTBL2/source/ltbl/quadtree/Quadtree.h
+++ b/LTBL2/source/ltbl/quadtree/Quadtree.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <ltbl/Quadtree/QuadtreeNode.h>
+#include <ltbl/quadtree/QuadtreeNode.h>
 
 #include <memory>
 

--- a/LTBL2/source/ltbl/quadtree/QuadtreeNode.cpp
+++ b/LTBL2/source/ltbl/quadtree/QuadtreeNode.cpp
@@ -1,6 +1,6 @@
-#include <ltbl/Quadtree/QuadtreeNode.h>
+#include <ltbl/quadtree/QuadtreeNode.h>
 
-#include <ltbl/Quadtree/Quadtree.h>
+#include <ltbl/quadtree/Quadtree.h>
 
 #include <assert.h>
 

--- a/LTBL2/source/ltbl/quadtree/QuadtreeNode.h
+++ b/LTBL2/source/ltbl/quadtree/QuadtreeNode.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <ltbl/Quadtree/QuadtreeOccupant.h>
+#include <ltbl/quadtree/QuadtreeOccupant.h>
 
 #include <memory>
 #include <array>

--- a/LTBL2/source/ltbl/quadtree/StaticQuadtree.cpp
+++ b/LTBL2/source/ltbl/quadtree/StaticQuadtree.cpp
@@ -1,4 +1,4 @@
-#include <ltbl/Quadtree/StaticQuadtree.h>
+#include <ltbl/quadtree/StaticQuadtree.h>
 
 #include <assert.h>
 

--- a/LTBL2/source/ltbl/quadtree/StaticQuadtree.h
+++ b/LTBL2/source/ltbl/quadtree/StaticQuadtree.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <ltbl/Quadtree/Quadtree.h>
+#include <ltbl/quadtree/Quadtree.h>
 
 namespace ltbl {
 	class StaticQuadtree : public Quadtree


### PR DESCRIPTION
As written on [the forum](http://en.sfml-dev.org/forums/index.php?topic=16895.msg133231#msg133231), there's an issue with the include directories capital letter for the `quadtree` directory.
