### PR TITLE
Fixed compile error from removal fix and -Wall,-Wextra warnings

### DIFF
--- a/LTBL2/source/ltbl/Math.cpp
+++ b/LTBL2/source/ltbl/Math.cpp
@@ -113,15 +113,15 @@ sf::FloatRect ltbl::rectExpand(const sf::FloatRect &rect, const sf::Vector2f &po
 bool ltbl::shapeIntersection(const sf::ConvexShape &left, const sf::ConvexShape &right) {
 	std::vector<sf::Vector2f> transformedLeft(left.getPointCount());
 
-	for (int i = 0; i < left.getPointCount(); i++)
+	for (unsigned i = 0; i < left.getPointCount(); i++)
 		transformedLeft[i] = left.getTransform().transformPoint(left.getPoint(i));
 
 	std::vector<sf::Vector2f> transformedRight(right.getPointCount());
 
-	for (int i = 0; i < right.getPointCount(); i++)
+	for (unsigned i = 0; i < right.getPointCount(); i++)
 		transformedRight[i] = right.getTransform().transformPoint(right.getPoint(i));
 
-	for (int i = 0; i < left.getPointCount(); i++) {
+	for (unsigned i = 0; i < left.getPointCount(); i++) {
 		sf::Vector2f point = transformedLeft[i];
 		sf::Vector2f nextPoint;
 
@@ -139,7 +139,7 @@ bool ltbl::shapeIntersection(const sf::ConvexShape &left, const sf::ConvexShape 
 
 		float minRightProj = vectorProject(transformedRight[0], edgePerpendicular);
 
-		for (int j = 1; j < right.getPointCount(); j++) {
+		for (unsigned j = 1; j < right.getPointCount(); j++) {
 			float proj = vectorProject(transformedRight[j], edgePerpendicular);
 
 			minRightProj = std::min(minRightProj, proj);
@@ -149,7 +149,7 @@ bool ltbl::shapeIntersection(const sf::ConvexShape &left, const sf::ConvexShape 
 			return false;
 	}
 
-	for (int i = 0; i < right.getPointCount(); i++) {
+	for (unsigned i = 0; i < right.getPointCount(); i++) {
 		sf::Vector2f point = transformedRight[i];
 		sf::Vector2f nextPoint;
 
@@ -167,7 +167,7 @@ bool ltbl::shapeIntersection(const sf::ConvexShape &left, const sf::ConvexShape 
 
 		float minRightProj = vectorProject(transformedLeft[0], edgePerpendicular);
 
-		for (int j = 1; j < left.getPointCount(); j++) {
+		for (unsigned j = 1; j < left.getPointCount(); j++) {
 			float proj = vectorProject(transformedLeft[j], edgePerpendicular);
 
 			minRightProj = std::min(minRightProj, proj);
@@ -199,7 +199,7 @@ sf::ConvexShape ltbl::shapeFixWinding(const sf::ConvexShape &shape) {
 	sf::Vector2f center = sf::Vector2f(0.0f, 0.0f);
 	std::list<sf::Vector2f> points;
 
-	for (int i = 0; i < shape.getPointCount(); i++) {
+	for (unsigned i = 0; i < shape.getPointCount(); i++) {
 		points.push_back(shape.getPoint(i));
 		center += shape.getPoint(i);
 	}
@@ -241,7 +241,7 @@ sf::ConvexShape ltbl::shapeFixWinding(const sf::ConvexShape &shape) {
 
 	sf::ConvexShape fixedShape(shape.getPointCount());
 
-	for (int i = 0; i < shape.getPointCount(); i++)
+	for (unsigned i = 0; i < shape.getPointCount(); i++)
 		fixedShape.setPoint(i, fixedPoints[i]);
 
 	return fixedShape;

--- a/LTBL2/source/ltbl/lighting/LightDirectionEmission.cpp
+++ b/LTBL2/source/ltbl/lighting/LightDirectionEmission.cpp
@@ -14,7 +14,7 @@ void LightDirectionEmission::render(const sf::View &view, sf::RenderTexture &lig
 	LightSystem::clear(lightTempTexture, sf::Color::White);
 
 	// Mask off light shape (over-masking - mask too much, reveal penumbra/antumbra afterwards)
-	for (int i = 0; i < shapes.size(); i++) {
+	for (unsigned i = 0; i < shapes.size(); i++) {
 		LightShape* pLightShape = static_cast<LightShape*>(shapes[i]);
 
 		// Get boundaries
@@ -37,7 +37,7 @@ void LightDirectionEmission::render(const sf::View &view, sf::RenderTexture &lig
 
 		float maxDist = 0.0f;
 
-		for (int j = 0; j < pLightShape->_shape.getPointCount(); j++)
+		for (unsigned j = 0; j < pLightShape->_shape.getPointCount(); j++)
 			maxDist = std::max(maxDist, vectorMagnitude(view.getCenter() - pLightShape->_shape.getTransform().transformPoint(pLightShape->_shape.getPoint(j))));
 
 		float totalShadowExtension = shadowExtension + maxDist;
@@ -65,7 +65,7 @@ void LightDirectionEmission::render(const sf::View &view, sf::RenderTexture &lig
 			states.shader = &unshadowShader;
 
 			// Unmask with penumbras
-			for (int j = 0; j < penumbras.size(); j++) {
+			for (unsigned j = 0; j < penumbras.size(); j++) {
 				unshadowShader.setParameter("lightBrightness", penumbras[j]._lightBrightness);
 				unshadowShader.setParameter("darkBrightness", penumbras[j]._darkBrightness);
 
@@ -98,7 +98,7 @@ void LightDirectionEmission::render(const sf::View &view, sf::RenderTexture &lig
 		lightTempTexture.setView(view);
 	}
 
-	for (int i = 0; i < shapes.size(); i++) {
+	for (unsigned i = 0; i < shapes.size(); i++) {
 		LightShape* pLightShape = static_cast<LightShape*>(shapes[i]);
 
 		if (pLightShape->_renderLightOverShape) {

--- a/LTBL2/source/ltbl/lighting/LightPointEmission.cpp
+++ b/LTBL2/source/ltbl/lighting/LightPointEmission.cpp
@@ -42,7 +42,7 @@ void LightPointEmission::render(const sf::View &view, sf::RenderTexture &lightTe
 	std::vector<OuterEdges> outerEdges(shapes.size());
 
 	// Mask off light shape (over-masking - mask too much, reveal penumbra/antumbra afterwards)
-	for (int i = 0; i < shapes.size(); i++) {
+	for (unsigned i = 0; i < shapes.size(); i++) {
 		LightShape* pLightShape = static_cast<LightShape*>(shapes[i]);
 
 		// Get boundaries
@@ -125,7 +125,7 @@ void LightPointEmission::render(const sf::View &view, sf::RenderTexture &lightTe
 			penumbraRenderStates.shader = &unshadowShader;
 
 			// Unmask with penumbras
-			for (int j = 0; j < penumbras.size(); j++) {
+			for (unsigned j = 0; j < penumbras.size(); j++) {
 				unshadowShader.setParameter("lightBrightness", penumbras[j]._lightBrightness);
 				unshadowShader.setParameter("darkBrightness", penumbras[j]._darkBrightness);
 
@@ -181,7 +181,7 @@ void LightPointEmission::render(const sf::View &view, sf::RenderTexture &lightTe
 			penumbraRenderStates.shader = &unshadowShader;
 
 			// Unmask with penumbras
-			for (int j = 0; j < penumbras.size(); j++) {
+			for (unsigned j = 0; j < penumbras.size(); j++) {
 				unshadowShader.setParameter("lightBrightness", penumbras[j]._lightBrightness);
 				unshadowShader.setParameter("darkBrightness", penumbras[j]._darkBrightness);
 
@@ -198,7 +198,7 @@ void LightPointEmission::render(const sf::View &view, sf::RenderTexture &lightTe
 		}
 	}
 
-	for (int i = 0; i < shapes.size(); i++) {
+	for (unsigned i = 0; i < shapes.size(); i++) {
 		LightShape* pLightShape = static_cast<LightShape*>(shapes[i]);
 
 		if (pLightShape->_renderLightOverShape) {

--- a/LTBL2/source/ltbl/lighting/LightSystem.cpp
+++ b/LTBL2/source/ltbl/lighting/LightSystem.cpp
@@ -66,7 +66,7 @@ void LightSystem::getPenumbrasPoint(std::vector<Penumbra> &penumbras, std::vecto
 		sf::Vector2f normal = vectorNormalize(sf::Vector2f(-pointToNextPoint.y, pointToNextPoint.x));
 
 		// Front facing, mark it
-		facingFrontBothEdges.push_back((vectorDot(firstEdgeRay, normal) > 0.0f && vectorDot(secondEdgeRay, normal) > 0.0f) || vectorDot(firstNextEdgeRay, normal) > 0.0f && vectorDot(secondNextEdgeRay, normal) > 0.0f);
+		facingFrontBothEdges.push_back((vectorDot(firstEdgeRay, normal) > 0.0f && vectorDot(secondEdgeRay, normal) > 0.0f) || (vectorDot(firstNextEdgeRay, normal) > 0.0f && vectorDot(secondNextEdgeRay, normal) > 0.0f));
 		facingFrontOneEdge.push_back((vectorDot(firstEdgeRay, normal) > 0.0f || vectorDot(secondEdgeRay, normal) > 0.0f) || vectorDot(firstNextEdgeRay, normal) > 0.0f || vectorDot(secondNextEdgeRay, normal) > 0.0f);
 	}
 
@@ -97,7 +97,7 @@ void LightSystem::getPenumbrasPoint(std::vector<Penumbra> &penumbras, std::vecto
 	}
 
 	// Compute outer boundary vectors
-	for (int bi = 0; bi < outerBoundaryIndices.size(); bi++) {
+	for (unsigned bi = 0; bi < outerBoundaryIndices.size(); bi++) {
 		int penumbraIndex = outerBoundaryIndices[bi];
 		bool winding = oneEdgeBoundaryWindings[bi];
 
@@ -117,7 +117,7 @@ void LightSystem::getPenumbrasPoint(std::vector<Penumbra> &penumbras, std::vecto
 		outerBoundaryVectors.push_back(winding ? firstEdgeRay : secondEdgeRay);
 	}
 
-	for (int bi = 0; bi < innerBoundaryIndices.size(); bi++) {
+	for (unsigned bi = 0; bi < innerBoundaryIndices.size(); bi++) {
 		int penumbraIndex = innerBoundaryIndices[bi];
 		bool winding = bothEdgesBoundaryWindings[bi];
 
@@ -376,8 +376,8 @@ void LightSystem::getPenumbrasDirection(std::vector<Penumbra> &penumbras, std::v
 		sf::Vector2f normal = vectorNormalize(sf::Vector2f(-pointToNextPoint.y, pointToNextPoint.x));
 
 		// Front facing, mark it
-		facingFrontBothEdges.push_back((vectorDot(firstEdgeRay, normal) > 0.0f && vectorDot(secondEdgeRay, normal) > 0.0f) || vectorDot(firstNextEdgeRay, normal) > 0.0f && vectorDot(secondNextEdgeRay, normal) > 0.0f);
-		facingFrontOneEdge.push_back((vectorDot(firstEdgeRay, normal) > 0.0f || vectorDot(secondEdgeRay, normal) > 0.0f) || vectorDot(firstNextEdgeRay, normal) > 0.0f || vectorDot(secondNextEdgeRay, normal) > 0.0f);
+		facingFrontBothEdges.push_back((vectorDot(firstEdgeRay, normal) > 0.0f && vectorDot(secondEdgeRay, normal) > 0.0f) || (vectorDot(firstNextEdgeRay, normal) > 0.0f && vectorDot(secondNextEdgeRay, normal) > 0.0f));
+		facingFrontOneEdge.push_back((vectorDot(firstEdgeRay, normal) > 0.0f || vectorDot(secondEdgeRay, normal) > 0.0f) || (vectorDot(firstNextEdgeRay, normal) > 0.0f || vectorDot(secondNextEdgeRay, normal) > 0.0f));
 	}
 
 	// Go through front/back facing list. Where the facing direction switches, there is a boundary
@@ -402,7 +402,7 @@ void LightSystem::getPenumbrasDirection(std::vector<Penumbra> &penumbras, std::v
 	if (facingFrontOneEdge[0] != facingFrontOneEdge[numPoints - 1])
 		outerBoundaryIndices.push_back(0);
 
-	for (int bi = 0; bi < innerBoundaryIndices.size(); bi++) {
+	for (unsigned bi = 0; bi < innerBoundaryIndices.size(); bi++) {
 		int penumbraIndex = innerBoundaryIndices[bi];
 		bool winding = bothEdgesBoundaryWindings[bi];
 
@@ -630,7 +630,7 @@ void LightSystem::render(const sf::View &view, sf::Shader &unshadowShader, sf::S
 
 	_lightPointEmissionQuadtree.queryRegion(viewPointEmissionLights, viewBounds);
 
-	for (int l = 0; l < viewPointEmissionLights.size(); l++) {
+	for (unsigned l = 0; l < viewPointEmissionLights.size(); l++) {
 		LightPointEmission* pPointEmissionLight = static_cast<LightPointEmission*>(viewPointEmissionLights[l]);
 
 		// Query shapes this light is affected by

--- a/LTBL2/source/ltbl/quadtree/DynamicQuadtree.h
+++ b/LTBL2/source/ltbl/quadtree/DynamicQuadtree.h
@@ -22,7 +22,7 @@ namespace ltbl {
 			_pRootNode = std::make_unique<QuadtreeNode>(rootRegion, 0, nullptr, this);
 		}
 
-		DynamicQuadtree(const DynamicQuadtree &other) {
+		DynamicQuadtree(const DynamicQuadtree &other) : Quadtree(other) {
 			*this = other;
 		}
 

--- a/LTBL2/source/ltbl/quadtree/Quadtree.cpp
+++ b/LTBL2/source/ltbl/quadtree/Quadtree.cpp
@@ -66,8 +66,6 @@ void Quadtree::queryRegion(std::vector<QuadtreeOccupant*> &result, const sf::Flo
 	// Query outside root elements
 	for (std::unordered_set<QuadtreeOccupant*>::iterator it = _outsideRoot.begin(); it != _outsideRoot.end(); it++) {
 		QuadtreeOccupant* oc = *it;
-		sf::FloatRect r = oc->getAABB();
-
 		if (oc != nullptr && region.intersects(oc->getAABB()))
 			// Intersects, add to list
 			result.push_back(oc);

--- a/LTBL2/source/ltbl/quadtree/Quadtree.h
+++ b/LTBL2/source/ltbl/quadtree/Quadtree.h
@@ -52,5 +52,6 @@ namespace ltbl {
 
 		friend class QuadtreeNode;
 		friend class SceneObject;
+		friend class QuadtreeOccupant;
 	};
 }

--- a/LTBL2/source/ltbl/quadtree/QuadtreeNode.cpp
+++ b/LTBL2/source/ltbl/quadtree/QuadtreeNode.cpp
@@ -7,8 +7,7 @@
 using namespace ltbl;
 
 QuadtreeNode::QuadtreeNode(const sf::FloatRect &region, int level, QuadtreeNode* pParent, Quadtree* pQuadtree)
-: _hasChildren(false),
-_region(region), _level(level), _pParent(pParent), _pQuadtree(pQuadtree),
+:  _pParent(pParent), _pQuadtree(pQuadtree), _hasChildren(false),  _region(region), _level(level),
 _numOccupantsBelow(0)
 {}
 
@@ -272,7 +271,7 @@ void QuadtreeNode::add(QuadtreeOccupant* oc) {
 	}
 	else {
 		// Check if we need a new partition
-		if (static_cast<signed>(_occupants.size()) >= _pQuadtree->_maxNumNodeOccupants && _level < _pQuadtree->_maxLevels) {
+		if (_occupants.size() >= _pQuadtree->_maxNumNodeOccupants && _level < _pQuadtree->_maxLevels) {
 			partition();
 
 			if (addToChildren(oc))

--- a/LTBL2/source/ltbl/quadtree/QuadtreeNode.h
+++ b/LTBL2/source/ltbl/quadtree/QuadtreeNode.h
@@ -20,9 +20,9 @@ namespace ltbl {
 
 		sf::FloatRect _region;
 
-		int _level;
+		unsigned _level;
 
-		int _numOccupantsBelow;
+		unsigned _numOccupantsBelow;
 
 		void getPossibleOccupantPosition(QuadtreeOccupant* oc, sf::Vector2i &point);
 

--- a/LTBL2/source/ltbl/quadtree/StaticQuadtree.h
+++ b/LTBL2/source/ltbl/quadtree/StaticQuadtree.h
@@ -11,7 +11,7 @@ namespace ltbl {
 			_pRootNode.reset(new QuadtreeNode(rootRegion, 0, nullptr, this));
 		}
 
-		StaticQuadtree(const StaticQuadtree &other) {
+		StaticQuadtree(const StaticQuadtree &other) : Quadtree(other) {
 			*this = other;
 		}
 


### PR DESCRIPTION
The last commit (fc7479543a680a4d72bebc57106fbe7c927e82cd) accessed a member in QuadTree that was protected. Additionally, the project had numerous warnings under g++ -Wall -Wextra that I've corrected.

Problems corrected:
- Fixed comparisons of ints against unsigned ints in for-loops
- DynamicQuadTree and StaticQuadTree's copy constructor should explicitly call QuadTree's copy constructor
- Adding parenthesis around &&s in ||s in LightSystem
- Some elements in QuadTreeNode's constructor were initialized out of order
