### PR TITLE
Fix for broken compile on some linux systems. atan2() requires math.h

### DIFF
--- a/LTBL2/source/ltbl/lighting/LightSystem.cpp
+++ b/LTBL2/source/ltbl/lighting/LightSystem.cpp
@@ -1,7 +1,7 @@
 #include <ltbl/lighting/LightSystem.h>
 
 #include <assert.h>
-#include <math.h>
+#include <cmath>
 #include <iostream>
 
 using namespace ltbl;

--- a/LTBL2/source/ltbl/lighting/LightSystem.cpp
+++ b/LTBL2/source/ltbl/lighting/LightSystem.cpp
@@ -1,7 +1,7 @@
 #include <ltbl/lighting/LightSystem.h>
 
 #include <assert.h>
-
+#include <math.h>
 #include <iostream>
 
 using namespace ltbl;


### PR DESCRIPTION
atan2 requires math.h on gcc compilers. 